### PR TITLE
fix(#62): apply fix to retrieve discord_id

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -40,7 +40,7 @@ def get_users():
 # DELETE endpoint
 @app.route('/users/delete', methods=['DELETE'])
 def delete_user():
-    discord_id = request.form.get('discord')
+    discord_id = request.json['discord']
     if discord_id:
         user = User()
         result = user.delete(discord=discord_id)


### PR DESCRIPTION
'discord_id' variable was not getting correct data from HTTP request hence entire DELETE endpoint couldn't perform deletion. The data is now taken directly from JSON from request.